### PR TITLE
fix(grow): route caddy to unique grow-frontend alias

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -9,8 +9,10 @@
 		reverse_proxy gateway:8080
 	}
 
-	# Everything else -> Next.js frontend
+	# Everything else -> Next.js frontend. Use the grow-specific alias (not the
+	# generic `frontend`) so it can't collide with another app's `frontend`
+	# service on the shared `edge` tunnel network.
 	handle {
-		reverse_proxy frontend:3000
+		reverse_proxy grow-frontend:3000
 	}
 }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -138,6 +138,12 @@ services:
     restart: unless-stopped
     depends_on:
       - gateway
+    # Unique alias so the caddy reverse_proxy never collides with another app's
+    # `frontend` on the shared `edge` network.
+    networks:
+      default:
+        aliases:
+          - grow-frontend
 
   caddy:
     image: caddy:2-alpine


### PR DESCRIPTION
On the shared 'edge' tunnel network the generic name 'frontend' also resolves to qrypto's frontend, so grow-caddy was proxying grow.klvdev.me to qrypto. Add a grow-specific 'grow-frontend' alias and point the Caddyfile at it so resolution is unambiguous.